### PR TITLE
Update to akka 2.5.2 and http 10.0.7 #6

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name=My Akka HTTP Project
 description=This is a seed project which creates a basic build for an Akka HTTP application using Scala.
 scala_version=2.12.2
-akka_http_version=10.0.6
-akka_version=2.5.1
+akka_http_version=10.0.7
+akka_version=2.5.2

--- a/src/main/g8/src/main/scala/com/example/WebServerHttpApp.scala
+++ b/src/main/g8/src/main/scala/com/example/WebServerHttpApp.scala
@@ -9,7 +9,8 @@ import akka.http.scaladsl.server.{ HttpApp, Route }
  */
 object WebServerHttpApp extends HttpApp with App {
   // Routes that this WebServer must handle are defined here
-  def route: Route =
+  // Please note this method was named `route` in versions prior to 10.0.7
+  def routes: Route =
     pathEndOrSingleSlash { // Listens to the top `/`
       complete("Server up and running") // Completes with some text
     } ~

--- a/src/main/g8/src/test/scala/com/example/WebServerHttpAppSpec.scala
+++ b/src/main/g8/src/test/scala/com/example/WebServerHttpAppSpec.scala
@@ -12,28 +12,28 @@ class WebServerHttpAppSpec extends WordSpec with Matchers with ScalatestRouteTes
 
   "WebServiceHttpApp" should {
     "answer to any request to `/`" in {
-      Get("/") ~> WebServer.routes ~> check {
+      Get("/") ~> WebServerHttpApp.routes ~> check {
         status shouldBe StatusCodes.OK
         responseAs[String] shouldBe "Server up and running"
       }
-      Post("/") ~> WebServer.routes ~> check {
+      Post("/") ~> WebServerHttpApp.routes ~> check {
         status shouldBe StatusCodes.OK
         responseAs[String] shouldBe "Server up and running"
       }
     }
     "answer to GET requests to `/hello`" in {
-      Get("/hello") ~> WebServerHttpApp.route ~> check {
+      Get("/hello") ~> WebServerHttpApp.routes ~> check {
         status shouldBe StatusCodes.OK
         responseAs[NodeSeq] shouldBe <html><body><h1>Say hello to akka-http</h1></body></html>
       }
     }
     "not handle a POST request to `/hello`" in {
-      Post("/hello") ~> WebServerHttpApp.route ~> check {
+      Post("/hello") ~> WebServerHttpApp.routes ~> check {
         handled shouldBe false
       }
     }
     "respond with 405 when not issuing a GET to `/hello` and route is sealed" in {
-      Put("/hello") ~> Route.seal(WebServerHttpApp.route) ~> check {
+      Put("/hello") ~> Route.seal(WebServerHttpApp.routes) ~> check {
         status shouldBe StatusCodes.MethodNotAllowed
       }
     }


### PR DESCRIPTION
Issue: #6 
To have the latest versions in the seed, the defaults are now the latest versions for Akka and Akka HTTP.
Includes a note pointing the rename of the `route` method to `routes`.